### PR TITLE
cause page carousel now working - style to follow

### DIFF
--- a/app/views/causes/cause_task_show.html.erb
+++ b/app/views/causes/cause_task_show.html.erb
@@ -3,14 +3,17 @@
     <h2><%= @cause.name %></h2>
     <div class="carousel-container">
       <div class="cause-carousel">
-        <h2> <&nbsp; Carousel &nbsp;> </h2>
-          <%= link_to previous_cause_path(index: @index, time: @time) do  %>
-          <button><</button>
-          <% end  %>
+        <%= link_to previous_cause_path(index: @index, time: @time) do  %>
+        <button><</button>
+        <% end  %>
+        <% if @cause.photo.attached? %>
+          <%= cl_image_tag (@cause.photo.key)%>
+        <% else %>
+          <img src="https://res.cloudinary.com/k2x4b-523p/image/upload/v1622768272/lym3euydklxpwbqztkui.jpg">
+        <% end %>
           <%= link_to next_cause_path(index: @index, time: @time) do  %>
           <button>></button>
           <% end  %>
-
           <div class="more-info"><button>Find out more. Click here</button></div>
       </div>
       <div class="progess-bar">


### PR DESCRIPTION
Added logic for images on cause page to reflect selected cause. Buttons either side of image provide access to next/previous image. 

Style to follow