### PR TITLE
images now stay highlighted once selected

### DIFF
--- a/app/assets/stylesheets/pages/_causes.scss
+++ b/app/assets/stylesheets/pages/_causes.scss
@@ -1,17 +1,17 @@
 // Specific CSS for your home-page
 .container {
-  border: #d1dfd4 4px solid;
+  // border: #d1dfd4 4px solid;
   padding: 4px;
 }
 
 .welcome {
-  border: #d1dfd4 4px solid;
+  // border: #d1dfd4 4px solid;
   margin: 8px;
   height: 100%;
 }
 
 .welcome-dashboard {
-  border: #d1dfd4 4px solid;
+  // border: #d1dfd4 4px solid;
   margin: 8px;
   height: 100%;
   display: flex;
@@ -20,13 +20,13 @@
 
 
 .choose {
-  border: #d1dfd4 4px solid;
+  // border: #d1dfd4 4px solid;
   margin: 8px;
   width: 100%;
 }
 
 .cause-cards {
-  border: #d1dfd4 4px solid;
+  // border: #d1dfd4 4px solid;
   padding: 4px;
   margin: 8px;
   display: grid;
@@ -35,39 +35,17 @@
   text-align: center;
 }
 .cause-card {
-  border: #d1dfd4 4px solid;
   padding: 4px;
   margin: 8px;
   height: 20vh;
   border-radius: 16px;
   position: relative;
-  background-color: white;
-  box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
+  // background-color: white;
+  // box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
   text-center: center;
-}
-
-.cause-card:hover {
-  transform: scale(0.90);
-  cursor: pointer;
-  color: #FFF;
-  text-decoration: underline;
-  text-decoration-color: black;
-}
-
-.cause-card-i {
-  border: #d1dfd4 4px solid;
-  padding: 4px;
-  margin: 8px;
-  border-radius: 8px;
-  font-size: italic;
-  position: absolute;
-  top: 50%;
-  transform: translate(50%, -50%);
-}
-.cause-card:hover {
-  transform: scale(1.02);
-  transition: .2s ease-in-out;
-  h3 { opacity: 0;}
+  .text-description {
+    opacity: 0;
+  }
 }
 .overlay {
   position: absolute;
@@ -77,12 +55,10 @@
   right: 0;
   height: 100%;
   width: 100%;
-  opacity: 0;
-  transition: .4s ease-in-out;
-  // background-color: #d1dfd4;
-}
-.cause-card:hover .overlay {
   opacity: 1;
+  transition: .4s ease-in-out;
+  // border: #D2E7D5 2px solid;
+  // background-color: #d1dfd4;
 }
 .text-description {
   color: black;
@@ -107,29 +83,35 @@
   align-items: center;
   object-fit: cover;
   vertical-align: middle;
+  filter: grayscale(100%);
 }
 .submit-card {
-  border: #d1dfd4 4px solid;
+  // border: #d1dfd4 4px solid;
   padding: 4px;
   margin: 8px;
   text-align: center;
 }
 .time-container {
-  border: #d1dfd4 4px solid;
+  // border: #d1dfd4 4px solid;
   padding: 4px;
   margin: 8px;
 }
-.time-card{
-  border: #d1dfd4 4px solid;
-  padding: 4px;
-  margin: 8px;
-  text-align: center;
-  border-radius: 16px;
-  background-color: white;
+.button-card{
+  background: #D2E7D5;
+  border:  1px solid #cccccc;
+  border-radius: 12px;
   box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
+  padding:  32px 68px;
+  color:  white;
+  margin: 50px auto;
+  font-family: 'Quicksand', sans-serif;
+  font-size: 25px;
+  text-align: center;
+  text-decoration: none;
+  width: 40%;
 }
 .time-cards {
-  border: #d1dfd4 4px solid;
+  // border: #d1dfd4 4px solid;
   padding: 4px;
   margin: 8px;
   display: grid;
@@ -137,87 +119,79 @@
   grid-gap: space-between;
   text-align: center;
 }
-
-.welcome {
-  border: #d1dfd4 4px solid;
-  margin: 8px;
-  height: 100%;
+body {
+  background-color: white;
 }
-.choose {
-  border: #d1dfd4 4px solid;
-  margin: 8px;
-  width: 100%;
-}
-
 .time-card:hover {
-  transform: scale(0.90);
-  cursor: pointer;
-  color: #FFF;
-  text-decoration: underline;
-  text-decoration-color: black;
+  transform: scale(1.03);
+  transition: .2s ease-in-out;
+  h3 { opacity: 0;}
 }
 
 h2 {
   text-align: center;
 }
+.clickable {
+  padding: 4px;
+  margin: 8px;
+  height: 20vh;
+  border-radius: 16px;
+  position: relative;
+  transition: 0.4s ease-out;
+  img { border: solid 2px black;}
+}
 h3 {
   color: black;
+  padding: 20%;
 }
-.clickable {
-  height: 100%;
-  border-radius: 8px;
-  background-color: #white;
-  cursor: pointer;
-  // box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
+
+a:hover {
+  text-decoration: none;
+}
+.clickable:hover {
+  h3 { opacity: 0;
+  transition: 0.4s ease-out;
+  text-decoration: none;
+}
+  .text-description {
+    opacity: 1;
+    transition: .4s ease-in-out;
+  }
+}
+.overlay:hover {
+  transform: scale(1.02);
+  transition: .2s ease-in-out;
 }
 .clickable.active {
   .text-description{ opacity: 0; transition: .4s ease-out;}
+  h3 { opacity: 0 }
   .photo img {
     opacity: 0.8;
     transition: .3s ease-in-out;
     transform: scale(1.04);
+    filter: grayscale(50%);
   }
 }
-.clickable.active {
-  .text-description{ opacity: 0;}
-  .photo img { opacity: 0.8;
+.select-time {
+  background: #D2E7D5;
+  border:  1px solid #cccccc;
+  border-radius: 12px;
+  box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
+  padding:  32px 68px;
+  color:  white;
+  margin: 50px auto;
+  font-family: 'Quicksand', sans-serif;
+  font-size: 25px;
+  text-align: center;
+  text-decoration: none;
+  width: 40%;
+}
+.select-time:hover {
+   transform: scale(1.03);
+   transition: .2s ease-in-out;
+  a {
+  color: darkgrey;
+  text-decoration: none;
+  transition: .2s ease-in-out;
   }
 }
-
-// h1 {
-//   font-weight: 700;
-//   color: black;
-//   text-shadow: 1px 1px 1px #919191,
-//         1px 2px 1px #919191,
-//         1px 3px 1px #919191,
-//         1px 4px 1px #919191,
-//         1px 5px 1px #919191,
-//         1px 6px 1px #919191,
-//         1px 7px 1px #919191,
-//         1px 8px 1px #919191,
-//         1px 9px 1px #919191,
-//         1px 10px 1px #919191,
-//     1px 18px 6px rgba(16,16,16,0.4),
-//     1px 22px 10px rgba(16,16,16,0.2),
-//     1px 25px 35px rgba(16,16,16,0.2),
-//     1px 30px 60px rgba(16,16,16,0.4);
-// }
-
-// h1 {
-//   font-weight: 700;
-//   color: black;
-//   text-shadow: 1px 1px 1px #919191,
-//         1px 2px 1px #919191,
-//         1px 3px 1px #919191,
-//         1px 4px 1px #919191,
-//         1px 5px 1px #919191,
-//         1px 6px 1px #919191,
-//         1px 7px 1px #919191,
-//         1px 8px 1px #919191,
-//         1px 9px 1px #919191,
-//         1px 10px 1px #919191,
-//     1px 18px 6px rgba(16,16,16,0.4),
-//     1px 22px 10px rgba(16,16,16,0.2),
-//     1px 25px 35px rgba(16,16,16,0.2),
-//     1px 30px 60px rgba(16,16,16,0.4);
-// }

--- a/app/controllers/causes_controller.rb
+++ b/app/controllers/causes_controller.rb
@@ -56,7 +56,7 @@ class CausesController < ApplicationController
         config.access_token_secret = ENV["ACCESS_TOKEN_SECRET"]
       end
       # @tweets = tweets.search('#Blacklivesmatter')
-      @tweets = client.user_timeline(@cause, count: 5)
+      @tweets = client.user_timeline(@cause.twitter, count: 2)
     @time = params[:time]
     @index = params[:index].to_i
    if USER_CAUSES.length > (@index * -1)
@@ -75,7 +75,7 @@ class CausesController < ApplicationController
         config.access_token_secret = ENV["ACCESS_TOKEN_SECRET"]
     end
       # @tweets = tweets.search('#Blacklivesmatter')
-      @tweets = client.user_timeline(@cause, count: 5)
+      @tweets = client.user_timeline(@cause.twitter, count: 2)
     @time = params[:time]
     @index = params[:index].to_i
     if USER_CAUSES.length > @index + 1

--- a/app/controllers/causes_controller.rb
+++ b/app/controllers/causes_controller.rb
@@ -56,7 +56,7 @@ class CausesController < ApplicationController
         config.access_token_secret = ENV["ACCESS_TOKEN_SECRET"]
       end
       # @tweets = tweets.search('#Blacklivesmatter')
-      @tweets = client.user_timeline(@cause.twitter, count: 2)
+      @tweets = client.user_timeline(@cause, count: 5)
     @time = params[:time]
     @index = params[:index].to_i
    if USER_CAUSES.length > (@index * -1)
@@ -75,7 +75,7 @@ class CausesController < ApplicationController
         config.access_token_secret = ENV["ACCESS_TOKEN_SECRET"]
     end
       # @tweets = tweets.search('#Blacklivesmatter')
-      @tweets = client.user_timeline(@cause.twitter, count: 2)
+      @tweets = client.user_timeline(@cause, count: 5)
     @time = params[:time]
     @index = params[:index].to_i
     if USER_CAUSES.length > @index + 1

--- a/app/views/causes/index.html.erb
+++ b/app/views/causes/index.html.erb
@@ -1,4 +1,3 @@
-<div class="welcome">
   <div class="choose">
     <h1>Welcome O.nline A.ctivist</h1>
     <div class="cause-container">
@@ -7,8 +6,8 @@
         <% @causes.each do |cause|%>
         <%= link_to add_selected_cause_path(cause), remote: true do %>
         <div class="cause-card">
-          <h3><%= cause.name %></h3>
           <div class="clickable">
+            <h3><%= cause.name %></h3>
             <div class="overlay">
               <div class="photo" >
                 <% if cause.photo.attached? %>
@@ -55,5 +54,4 @@
       </div>
     </div>
   </div>
-</div>
 </div>


### PR DESCRIPTION
I've been playing around with the cause buttons today. Thoughts on the below please. 

**Required changes**

1. Updated CSS so selected causes now stay highlighted even after moving away from the button. This is fundamentally what I was looking to do from day one. Finally figured it out. Happy to cover it with you guys.

2. Centred the hashtags on the boxes.

**Additional (optional) changes.** 

3. Added Opacity of 0.15 and a 100% grayscale layer to the unselected buttons so a light, greyed out image is always showing. This gives our page something other than 8 solid white boxes while maintaining a level of cleanliness to it. (Editable)

4. The selected causes have a muted colour to them (20% grayscale, 80% opacity) so the bold colours do not clash with our overall pastel design. (Again, easily editable)

5. Removed all DIV borders so the page layout is more 'how it will be'. 

**Still to do.**

6. Resize all images so they are correct for the boxes. This might require swapping some images entirely due to them being almost square in the original and cropping not being an option without chopping off vital parts of the image. 

<img width="1662" alt="Screenshot 2021-06-13 at 12 43 46" src="https://user-images.githubusercontent.com/76408528/121805877-0f833980-cc45-11eb-8166-491e8c5af250.png">