### PR TITLE
updated cause controller tweet numbers

### DIFF
--- a/app/controllers/causes_controller.rb
+++ b/app/controllers/causes_controller.rb
@@ -62,7 +62,7 @@ class CausesController < ApplicationController
         config.access_token_secret = ENV["ACCESS_TOKEN_SECRET"]
       end
       # @tweets = tweets.search('#Blacklivesmatter')
-      @tweets = client.user_timeline(@cause.twitter, count: 2)
+      @tweets = client.user_timeline(@cause.twitter, count: 30)
     render :cause_task_show
   end
   def next_cause
@@ -76,7 +76,7 @@ class CausesController < ApplicationController
         config.access_token_secret = ENV["ACCESS_TOKEN_SECRET"]
     end
       # @tweets = tweets.search('#Blacklivesmatter')
-      @tweets = client.user_timeline(@cause.twitter, count: 2)
+      @tweets = client.user_timeline(@cause.twitter, count: 30)
     @time = params[:time]
     if USER_CAUSES.length > @index + 1
       @index += 1


### PR DESCRIPTION
Super quick fix. 

The tweet count when arriving on the page was 30. For next_cause and previous_cause it was still 2. 

I updated both of these to 30 so when you scroll through causes the number of tweets stays at 30. 