### PR TITLE
Revert "Fixed carousel buttons"

### DIFF
--- a/app/assets/stylesheets/pages/_cause_task_show.scss
+++ b/app/assets/stylesheets/pages/_cause_task_show.scss
@@ -133,13 +133,12 @@ border-bottom: solid 8px #6ec5ee;
   height: 40vh;
   width: 80%;
   margin: auto;
-  border-radius: 8px;
-  padding-top: 25px;
+  border-radius: 16px;
   img {
     width: 40vw;
     height: 40vh;
     margin: auto;
-    object-fit: cover;
+    object-fit: contain;
     border-radius: 16px;
     opacity: 0.8;
   }
@@ -199,7 +198,6 @@ h3 {
 }
 .carousel-image {
   position: relative;
-
 }
 .arrow-left {
   font-size: 50px;


### PR DESCRIPTION
The back arrow seems to have stopped working. It's fine on the dashboard but on the cause_task_show page you get stuck. 

This carousel logic needed another look anyways? I think @aljohnson91 was going to do a ticket for it?

This PR is to revert this merge until the back arrow is fixed