### PR TITLE
added larger gap between task/twitter feed and footer

### DIFF
--- a/app/assets/stylesheets/pages/_cause_task_show.scss
+++ b/app/assets/stylesheets/pages/_cause_task_show.scss
@@ -17,7 +17,7 @@ body {
   height: 40vh;
 }
 .page-container {
-  height: 100%;
+  height: 120vh;
 }
 .page-container-background{
   background-image: linear-gradient(rgba(255,255,255,0.7),rgba(255,255,255,0.7)), url("https://res.cloudinary.com/k2x4b-523p/image/upload/v1623112549/n2omdnrbdzk3bk7w7jzf.jpg");


### PR DESCRIPTION
Updated the height of the page container from 100% to 120vh. 

Height chosen to not 'squash' the people on the wallpaper underneath or have them affected by the box-shadow. 10 sec change if you wish to put it back. 

<img width="1517" alt="Screenshot 2021-06-24 at 14 39 35" src="https://user-images.githubusercontent.com/76408528/123272868-0d00c980-d4fa-11eb-9b4d-5b8e59735989.png">
