### PR TITLE
resized cause_task_show page

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -11,7 +11,7 @@ a {
   display:inline-block;
   text-decoration: none;
   font-weight: 400;
-  text-shadow: 1px 1px 3px rgba(0,0,0,0.2);
+  // text-shadow: 1px 1px 3px rgba(0,0,0,0.2);
 }
 .form h2 {
   text-align: center;

--- a/app/assets/stylesheets/components/_tasks.scss
+++ b/app/assets/stylesheets/components/_tasks.scss
@@ -11,7 +11,7 @@
 .checkboxes:checked + label {
   border: 2px solid #D2E7D5;
   background: rgb(210,231,213);
-  background: linear-gradient(90deg, rgba(210,231,213,1) 8%, rgba(255,255,255,1) 8%);
+  background: linear-gradient(90deg, rgba(210,231,213,1) 12%, rgba(255,255,255,1) 12%);
   transform: scale(0.99);
   transition: .4s ease;
 

--- a/app/assets/stylesheets/components/_twitter.scss
+++ b/app/assets/stylesheets/components/_twitter.scss
@@ -3,7 +3,7 @@
   border-right: 4px #6ec5ee solid;
   box-shadow: 0 10px 30px 0 rgba(grey, .5);
   padding: 20px;
-  margin: 30px;
+  margin-top: 30px;
   border-radius: 0px 0px 16px 0px;
   height: auto;
 }

--- a/app/assets/stylesheets/pages/_cause_task_show.scss
+++ b/app/assets/stylesheets/pages/_cause_task_show.scss
@@ -17,51 +17,61 @@ body {
   height: 40vh;
 }
 .page-container {
-  height: 120vh;
+  height: 135vh;
+}
+.next-button{
+  height: 0px;
 }
 .page-container-background{
   background-image: linear-gradient(rgba(255,255,255,0.7),rgba(255,255,255,0.7)), url("https://res.cloudinary.com/k2x4b-523p/image/upload/v1623112549/n2omdnrbdzk3bk7w7jzf.jpg");
   opacity: 0.9;
-  background-position: 0px -120px;
+  background-size: 60%;
+  background-position: 35px -80px;
 }
 .card-topper {
-  height: 15vh;
-  border-bottom: solid 8px #d1dfd4;
+  height: 25%;
+  border-bottom: solid 8px #D2E7D5;
+
 }
 .card-topper-left {
-border-bottom: solid 8px #6ec5ee;
+  height: 25%;
+  border-bottom: solid 8px #6ec5ee;
 }
 .cause-show-card-right {
+  height: 25%;
   box-shadow: 0 10px 30px 0 rgba(grey, .5);
 }
 .cause-show-card {
-  height: 60vh;
+  height: 65vh;
   margin: 30px;
-  border-radius: 16px;
+  border-radius: 8px;
   flex: 2;
   background-color: #f6f6f6;
   border: solid 1px #lightgrey;
   h3 {
-    font-size: 25px;
+    font-size: 18px;
     color: black;
     text-align: center;
-    padding:15px;
-    border-radius: 16px;
-  }
+    padding-top: 15px;
+    border-radius: 8px;
+    }
   h2 {
-    font-size: 25px;
+    font-size: 16px;
     color: black;
     text-align: center;
     padding:15px;
-    border-radius: 16px;
-  }
+    border-radius: 8px;
+    // background-color: #f6f6f6;
+    }
   h6 {
-    font-size: 20px;
+    font-size: 14px;
+    font-family: 'Quicksand', sans-serif;
     color: black;
     text-align: center;
-    padding-bottom: 15px;
+    padding: 10px 0px 17px 0px;
     width: 100%;
     box-shadow: 0 1.5em 2.5em -.5em rgba(#000000, .1);
+    background-color: #f6f6f6;
   }
 }
 .cause-show-cards {
@@ -105,16 +115,16 @@ border-bottom: solid 8px #6ec5ee;
   box-shadow: 0 1.5em 2.5em -.5em rgba(#000000, .1);
   border: 1px solid lightgrey;
   a { color: black;
-    font-size: 20px;
+    font-size: 22px;
     padding: 10px;
     margin-left: 42px;
     width: 90%;
-    border-left: 1px solid lightgrey;
+    border-left: 1px solid #D2E7D5;
   }
 }
 .form-check-label:hover {
   background: rgb(246,246,246);
-  background: linear-gradient(90deg, rgba(246,246,246,1) 8%, rgba(210,231,213,1) 8%);
+  background: linear-gradient(90deg, rgba(246,246,246,1) 12%, rgba(210,231,213,1) 12%);
   transition: .4s ease;
   a { border-left: 1px solid #D2E7D5;
     transition: .4s ease;
@@ -122,30 +132,42 @@ border-bottom: solid 8px #6ec5ee;
 }
 .timeform b {
   position: absolute;
+  padding-top: 10px;
   bottom: 5px;
   right: 10px;
-  font-size: 18px;
+  font-size: 14px;
 }
 .timeform {
   display: block;
   padding: 20px;
-  height: 44vh;
+  height: 47vh;
   overflow: scroll;
+  a {font-size: 16px;}
 }
 .carousel-container {
   display: flex;
-  width: 80%;
+  align-self: end;
+  width: 78%;
   margin: auto;
 }
  .twitter-card{
   display: block;
-  padding: 20px;
-  height: 44vh;
+  padding: 0px 25px 20px 25px;
+  height: 47vh;
   overflow: scroll;
+}
+.tweet {
+  font-family: 'Quicksand', sans-serif;
+  position: relative;
+}
+.twitter-header {
+  display: flex;
+  justify-content: space-around;
+  text-align: center;
 }
 .cause-carousel {
   display: flex;
-  padding: 20px;
+  padding: 10px;
   position: relative;
   h6 {
   text-align: center;
@@ -164,8 +186,8 @@ border-bottom: solid 8px #6ec5ee;
     height: 40vh;
     margin: auto;
     object-fit: cover;
-    border-radius: 16px;
-    opacity: 0.8;
+  border-radius: 8px;
+      opacity: 0.8;
   }
 }
 .cause-container {
@@ -187,27 +209,35 @@ h3 {
 .organisations-info {
   flex: 0.7;
   margin: 17% 3% 0 20px;
-  padding: 20px;
-  height: 20vh;
-  border-radius: 16px;
+  padding: 10px;
+  height: 25vh;
+  border-radius: 8px;
+  font-family: 'Quicksand', sans-serif;
   box-shadow: 0 10px 30px 0 rgba(grey, .5);
   background-color: #f6f6f6;
-  h4 { text-align: center;}
+  h5 { text-align: center;
+    font-family: 'Quicksand', sans-serif;
+}
   p { text-align: center;
     margin: auto;
     padding: 12px;
-    font-size: 18px;}
+    font-size: 14px;
+  }
 }
 .more-info-show {
   flex: 0.7;
   margin: 17% 20px 0 3%;
-  padding: 20px;
-  height: 20vh;
-  border-radius: 16px;
+  padding: 10px;
+  height: 25vh;
+  border-radius: 8px;
   box-shadow: 0 10px 30px 0 rgba(grey, .5);
   background-color: #f6f6f6;
-  h4 { text-align: center;}
-  p { text-align: center;}
+  h5 { text-align: center;
+  font-family: 'Quicksand', sans-serif;
+}
+  p { text-align: center;
+    font-family: 'Quicksand', sans-serif;
+      font-size: 13px;}
 }
 h3 {
   margin: .5em 0;
@@ -240,4 +270,9 @@ h3 {
   opacity: 1;
   text-transform: scale(1.03);
   cursor: pointer;
+}
+.tweet-created-at {
+  position: absolute;
+  right: 20px;
+  bottom: 10px;
 }

--- a/app/views/causes/cause_task_show.html.erb
+++ b/app/views/causes/cause_task_show.html.erb
@@ -2,7 +2,7 @@
   <div class="page-container">
     <div class="carousel-container">
       <div class="more-info-show">
-        <h4>About:</h4>
+        <h5>About:</h5>
         <p><%= @cause.description %></p>
       </div>
       <div class="cause-carousel">
@@ -25,7 +25,7 @@
         </div>
       </div>
       <div class="organisations-info">
-        <h4>Notable organisations:</h4>
+        <h5>Notable organisations:</h5>
         <% @organisations.each do |organisation| %>
         <p><a href="<%= organisation.url %>"><%= organisation.name %></a></p>
         <%end%>
@@ -36,19 +36,19 @@
         <div class="cause-show-card cause-show-card-left">
           <div class="card-topper card-topper-left">
             <h3> Find out the latest news about <br> <%= @cause.name %></h3>
-            <h6> &nbsp;<br>&nbsp; </h6>
+            <div class="twitter-header">
+              <img src="<%= @cause.photo_url %>" class="top-container-image-style" style="height: 48px;width: 48px;" alt="">
+              <span>Jun 26, 2021 </span>
+              <img src="https://upload.wikimedia.org/wikipedia/fr/c/c8/Twitter_Bird.svg" style="height: 48px;width: 48px;" alt="">
+            </div>
           </div>
           <div class="twitter-card">
-          <img src="<%= @cause.photo_url %>" class="top-container-image-style" style="height: 48px;width: 48px;" alt="">
-          <span>Jun 26, 2021 </span>
-          <img src="https://upload.wikimedia.org/wikipedia/fr/c/c8/Twitter_Bird.svg" style="height: 48px;width: 48px;" alt="">
-          <br>
             <% @tweets.each do |tweet| %>
             <div class="tweet">
-              User <b> @<%= tweet.user.screen_name %> </b> said: "<%= tweet.text %>" on <b class="tweet-created-at"> <%= tweet.created_at.strftime('%-m/%d/%Y') %> </b>
+              <b> @<%= tweet.user.screen_name %> </b> said: "<%= tweet.text %>" <br><br> <b class="tweet-created-at"> <%= tweet.created_at.strftime('%-m/%d/%Y') %> </b>
             </div>
-          <% end %>
-        </div>
+            <% end %>
+          </div>
         </div>
         <div class="cause-show-card cause-show-card-right">
         <%= render 'task_list' %>


### PR DESCRIPTION
Same for the cause_task_show page... Image below at 100% zoom on Chrome. 

I moved the Twitter bits to the card-header to fill in the gap. It also keep it in view for more than 2 seconds. I've done the same with the tweet date as I did with points too, just for uniformity. 

The work to get the background image to the right size 😟 lol.

<img width="1430" alt="Screenshot 2021-06-25 at 03 59 30" src="https://user-images.githubusercontent.com/76408528/123363194-de223c00-d569-11eb-812c-1c9944fe23c5.png">

<img width="1433" alt="Screenshot 2021-06-25 at 04 02 21" src="https://user-images.githubusercontent.com/76408528/123363342-2ccfd600-d56a-11eb-9259-049f6170967b.png">